### PR TITLE
fix: Corrected logic for checking if a product is deleted

### DIFF
--- a/src/BookStore.Client/wwwroot/js/main.js
+++ b/src/BookStore.Client/wwwroot/js/main.js
@@ -336,8 +336,7 @@
                 return;
             }
             const isDeleted = $(this).attr('data-book-isDeleted');
-            console.log(isDeleted)
-            if (isDeleted) {
+            if (isDeleted === "true" || isDeleted === "True") {
                 $.toast({
                     heading: 'Error',
                     text: 'This product is no longer available.',


### PR DESCRIPTION
Previously, the logic compared `data-book-isDeleted` value directly with "true" or "True", which could lead to incorrect handling. Updated to ensure proper validation